### PR TITLE
[reactController] remove motionPlan, read trajectories directly from port

### DIFF
--- a/modules/reactController/CMakeLists.txt
+++ b/modules/reactController/CMakeLists.txt
@@ -5,7 +5,6 @@
 project(reactController)
 
 find_package(IPOPT REQUIRED)
-find_package(reaching-with-avoidance)
 
 include(YarpIDL)
 
@@ -25,14 +24,13 @@ yarp_add_idl(IDL_GEN_FILES ${PROJECT_NAME}.thrift)
 source_group("IDL Files" FILES ${idl_files})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
-                    ${reaching-with-avoidance_INCLUDE_DIRS}
                     ${IPOPT_INCLUDE_DIRS}
                     ${YARP_INCLUDE_DIRS}                    
                     ${ICUB_INCLUDE_DIRS})
 
 add_definitions(${IPOPT_DEFINITIONS} -D_USE_MATH_DEFINES)
 add_executable(${PROJECT_NAME} ${header_files} ${source_files} ${IDL_GEN_FILES} ${idl_files})
-target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ctrlLib iKin skinDynLib  ${reaching-with-avoidance_LIBRARIES} ${IPOPT_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES} ctrlLib iKin skinDynLib  ${IPOPT_LIBRARIES})
 set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " ${IPOPT_LINK_FLAGS}")
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 

--- a/modules/reactController/include/reactCtrlThread.h
+++ b/modules/reactController/include/reactCtrlThread.h
@@ -39,7 +39,6 @@
 #include <iCub/ctrl/minJerkCtrl.h>
 #include <iCub/ctrl/pids.h>
 #include <iCub/ctrl/filters.h>
-#include <iCub/motionPlan/motionPlan.h>
 
 #include <iostream>
 #include <fstream>
@@ -235,7 +234,7 @@ protected:
     yarp::sig::Vector circleCenter;
 
     bool streamingTarget;
-    motionPlan *nextStreamedTargets;
+    yarp::os::BufferedPort<yarp::os::Bottle> streamedTargets;
     std::vector<ControlPoint> additionalControlPointsVector; 
   
     
@@ -364,6 +363,12 @@ protected:
     **/
     void sendData();
 
+    /**
+    * @brief Receive trajectories of control points from planner
+    * @param x_desired standard vector of set of 3D points
+    * @return true if received trajectories are valid, false otherwise
+    */
+    bool readMotionPlan(std::vector<yarp::sig::Vector> &x_desired);
 
     /***************************** visualizations in icubGui  ****************************/
     //uses corresponding global variables for target pos (x_d) or particle pos (x_n) and creates bottles for the port to iCubGui

--- a/modules/reactController/src/reactCtrlThread.cpp
+++ b/modules/reactController/src/reactCtrlThread.cpp
@@ -415,11 +415,10 @@ void reactCtrlThread::run()
                 setNewTarget(x_planned[0],false);
                 if (x_planned.size()==2 && additionalControlPoints)
                 {
-                    ControlPoint *ctrlPt = new ControlPoint();
-                    ctrlPt->type = "Elbow";
-                    ctrlPt->x_desired = x_planned[1];
-                    additionalControlPointsVector.push_back(*ctrlPt);
-                    delete ctrlPt;
+                    ControlPoint ctrlPt;
+                    ctrlPt.type = "Elbow";
+                    ctrlPt.x_desired = x_planned[1];
+                    additionalControlPointsVector.push_back(ctrlPt);
                 }
             }
         }

--- a/modules/reactController/src/reactCtrlThread.cpp
+++ b/modules/reactController/src/reactCtrlThread.cpp
@@ -419,6 +419,7 @@ void reactCtrlThread::run()
                     ctrlPt->type = "Elbow";
                     ctrlPt->x_desired = x_planned[1];
                     additionalControlPointsVector.push_back(*ctrlPt);
+                    delete ctrlPt;
                 }
             }
         }


### PR DESCRIPTION
The main purpose of this `PR` is:
- Remove `motionPlan` dependency 
- Introduce 1 new method to read trajectories from `planner` directly from port.

It is tested on simulation. The behavior of integration is the same!

cc @matejhof @pattacini 