### PR TITLE
fixed avoiding speed units in AvoidanceHandler

### DIFF
--- a/modules/reactController-sim/main.cpp
+++ b/modules/reactController-sim/main.cpp
@@ -674,9 +674,9 @@ public:
     {
         type="tactile";
 
-        // produce 50 deg/s repulsive
+        // produce 1 rad/s repulsive
         // velocity for 1 mm of penetration
-        k=50.0/0.001;
+        k= 1.0/0.001; // 50.0/0.001;
 
         parameters.unput("k");
         parameters.put("k",k);

--- a/modules/reactController/src/avoidanceHandler.cpp
+++ b/modules/reactController/src/avoidanceHandler.cpp
@@ -206,8 +206,8 @@ AvoidanceHandlerTactile::AvoidanceHandlerTactile(const iCub::iKin::iKinChain &_c
 {
     type="tactile";
 
-    avoidingSpeed = 50;
-    // produce collisionPoint.magnitude * avoidingSpeed deg/s repulsive speed 
+    avoidingSpeed = 1;
+    // produce collisionPoint.magnitude * avoidingSpeed rad/s repulsive speed
         
     parameters.unput("avoidingSpeed");
     parameters.put("avoidingSpeed",avoidingSpeed);


### PR DESCRIPTION
This PR solves the bug in avoiding speed units in AvoidanceHandler after fixing joint velocities units (#25) .